### PR TITLE
Install under /usr by default

### DIFF
--- a/patch-image.sh
+++ b/patch-image.sh
@@ -23,7 +23,7 @@ do
     git checkout FETCH_HEAD
 
     SKIP_GENERATE_AUTHORS=1 SKIP_WRITE_GIT_CHANGELOG=1 python3 setup.py sdist
-    pip3 install dist/*.tar.gz
+    pip3 install --prefix /usr dist/*.tar.gz
 done < "$patch_file"
 
 cd /


### PR DESCRIPTION
Should be the correct prefix for the python libs