### PR TITLE
Fix missing repos in OCP images

### DIFF
--- a/Dockerfile.patch
+++ b/Dockerfile.patch
@@ -3,12 +3,15 @@ ARG MY_IMAGE=ocp_image
 FROM $MY_IMAGE
 
 ARG PATCH_LIST=patch-list.txt
+ARG REPO_LIST=ubi8.repo
 ENV PATCH_FILE="${PATCH_LIST}"
+ENV REPO_FILE="${REPO_LIST}"
 
-COPY "${PATCH_FILE}" /tmp/
+COPY "${PATCH_FILE}" "${REPO_FILE}" /tmp/
 COPY patch-image.sh /bin/
 
 RUN echo "patch list file: ${PATCH_FILE}" \
+ && if [ ! "$(ls -A /etc/yum.repos.d/)" ]; then cp /tmp/${REPO_FILE} /etc/yum.repos.d/; fi \
  && dnf install -y git python3 python3-pip wget unzip patch \
  && /bin/patch-image.sh \
  && rm -f /bin/patch-image.sh \

--- a/patch-list.txt
+++ b/patch-list.txt
@@ -1,1 +1,3 @@
+PATCH openstack/sushy https://review.opendev.org/changes/openstack%2Fsushy~830553/revisions/13/patch?zip
+PATCH openstack/sushy https://review.opendev.org/changes/openstack%2Fsushy~831355/revisions/1/patch?zip
 PATCH openstack/sushy https://review.opendev.org/changes/openstack%2Fsushy~830322/revisions/12/patch?zip

--- a/ubi8.repo
+++ b/ubi8.repo
@@ -1,0 +1,14 @@
+[ubi-8-baseos]
+name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-appstream]
+name = Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+


### PR DESCRIPTION
In OCP images the repos are cleaned up, we can use alternative repos
for that.
The ubi8 repos are provided as example, they need to be adapted based
on the main distribution used by the image we want to modify.